### PR TITLE
make verbose log output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/ecto_boot_migration.svg)](https://hex.pm/packages/ecto_boot_migration)
 [![Hex.pm](https://img.shields.io/hexpm/dt/ecto_boot_migration.svg)](https://hex.pm/packages/ecto_boot_migration)
 
-Helper module for Elxiir that can be used to easily ensure that Ecto database 
+Helper module for Elxiir that can be used to easily ensure that Ecto database
 was migrated before rest of the application was started.
 
 ## Rationale
 
-There are many strategies how to deal with this issue, 
+There are many strategies how to deal with this issue,
 e.g. see https://github.com/bitwalker/distillery/blob/master/docs/Running%20Migrations.md
 
-However, if you have any workers that are relying on the DB schema that are 
-launched upon boot with some methods, such as release post_start hooks you 
-can easily enter race condition. Application may crash as these workers will 
-not find tables or columns they expect and it will happen sooner than the 
+However, if you have any workers that are relying on the DB schema that are
+launched upon boot with some methods, such as release post_start hooks you
+can easily enter race condition. Application may crash as these workers will
+not find tables or columns they expect and it will happen sooner than the
 post_start hook script will send the commands to the the application process.
 
-In stateless environments such as Docker it is just sometimes more convenient 
+In stateless environments such as Docker it is just sometimes more convenient
 to perform migration upon boot. This is exactly what this library does.
 
 By default if any migrations have happened it will kill the application.
@@ -27,12 +27,12 @@ or some processes are started due to migration process that will later
 cause issues. This feature can be disabled by passing an argument to
 the migration-related functions.
 
-Currently it works only with PostgreSQL databases but that will be easy to 
+Currently it works only with PostgreSQL databases but that will be easy to
 extend.
 
 ## Installation
 
-The package can be installed by adding `ecto_boot_migration` to your list of 
+The package can be installed by adding `ecto_boot_migration` to your list of
 dependencies in `mix.exs`:
 
 ```elixir
@@ -61,6 +61,15 @@ defmodule MyApp do
     Supervisor.start_link(children, [strategy: :one_for_one, name: MyApp.Supervisor])
   end
 end
+```
+
+
+To see verbose debug output, configure `debug: true`:
+
+```elixir
+## in config/config.exs
+config :ecto_boot_migration,
+  debug: true
 ```
 
 

--- a/lib/ecto_boot_migration.ex
+++ b/lib/ecto_boot_migration.ex
@@ -97,12 +97,10 @@ defmodule EctoBootMigration do
       start_dependencies()
       repos = Application.get_env(app, :ecto_repos, [])
       repos_pids = start_repos(repos)
-      run_migrations(repos)
+      migrations = run_migrations(repos)
       stop_repos(repos_pids)
 
       log("Done")
-      migrations = []
-
       case migrations do
         [] ->
           {:ok, :noop}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.2.8", "a4463c0928b970f2cee722cd29aaac154e866a15882c5737e0038bbfcf03ec2c", [], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"}}
+%{
+  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.8", "a4463c0928b970f2cee722cd29aaac154e866a15882c5737e0038bbfcf03ec2c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+}


### PR DESCRIPTION
also: 
- split up into smaller functions
- formatting with Elixir-formatter
- a small bugfix (migrations were always `[]` near the end of the function) 
