### PR TITLE
parantheses for config call

### DIFF
--- a/lib/ecto_boot_migration.ex
+++ b/lib/ecto_boot_migration.ex
@@ -237,7 +237,7 @@ defmodule EctoBootMigration do
   end
 
   defp priv_path_for(repo, filename) do
-    app = Keyword.get(repo.config, :otp_app)
+    app = Keyword.get(repo.config(), :otp_app)
     repo_underscore = repo |> Module.split() |> List.last() |> Macro.underscore()
     Path.join([priv_dir(app), repo_underscore, filename])
   end


### PR DESCRIPTION
to fix:

```
warning: using map.field notation (without parentheses) to invoke function X.config() is deprecated, you must add parentheses instead: remote.function()
```

when running boot migrations on process startup on Elixir 1.17